### PR TITLE
Cleanup plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,3 @@ prefix: FC
 authors: [DarkEyeDragon]
 description: Let players fly on their carpet
 website: https://darkeyedragon.me
-commands:
-  carpet:
-    description: Create a carpet for yourself or others
-    usage: /carpet [username] [block material]


### PR DESCRIPTION
The commands section in the plugin.yml is only needet when you use the cmd listener from Bukkit.